### PR TITLE
fix typo in visit URL

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -46,7 +46,7 @@ info_installation_done() {
     echo "   make start"
     echo "--------------------------------------"
     echo ""
-    echo "For complete documentaiton, visit: https://www.avd.sh/docs/installation/setup-environement/"
+    echo "For complete documentaiton, visit: https://www.avd.sh/en/latest/docs/installation/setup-environment/"
     echo ""
 }
 


### PR DESCRIPTION
The visit URL had 2 mistakes, fixed it to point to the correct one aka https://avd.sh/en/latest/docs/installation/setup-environment/